### PR TITLE
Fix/cancel reservation session

### DIFF
--- a/src/app/booking/[businessUrl]/landing.tsx
+++ b/src/app/booking/[businessUrl]/landing.tsx
@@ -27,15 +27,16 @@ export function BusinessLanding(props: BusinessDataResponse) {
 
     // Check for cancellation status in URL
     const status = searchParams.get("status");
-    const productId = searchParams.get("productId");
-    const productType = searchParams.get("productType");
+    const sessionId = searchParams.get("sessionId");
 
-    if (status === "canceled" && productId && productType) {
+    if (status === "canceled" && sessionId) {
       const handleCancellation = async () => {
         try {
+          // The backend expires the Stripe checkout session, which releases the
+          // slot/seat via the checkout.session.expired webhook. Keyed on the
+          // (unguessable) session id rather than a product id.
           await api.post("/cancel-reservation", {
-            productId,
-            productType,
+            sessionId,
           });
         } catch (error) {
           console.error("Failed to process cancellation:", error);

--- a/src/app/dashboard/appointments/page.tsx
+++ b/src/app/dashboard/appointments/page.tsx
@@ -129,7 +129,7 @@ export default function AppointmentsPage() {
                   .filter((member) => member.status === "accepted")
                   .map((member) => (
                     <SelectItem key={member.id} value={member.id.toString()}>
-                      {member.User.full_name} ({member.User.email})
+                      {member.user.full_name} ({member.user.email})
                     </SelectItem>
                   ))
               ) : (

--- a/src/app/dashboard/appointments/page.tsx
+++ b/src/app/dashboard/appointments/page.tsx
@@ -16,6 +16,7 @@ import { useQuery } from "@tanstack/react-query";
 import api from "@/services/api-service";
 import { AppointmentList } from "@/components/appointments/appointment-list";
 import { useCompanyDetails } from "@/hooks/use-company-details";
+import { useGetStaffs } from "@/hooks/use-get-staffs";
 
 export default function AppointmentsPage() {
   const { data: settings } = useCompanyDetails();
@@ -29,26 +30,19 @@ export default function AppointmentsPage() {
   const isStaff = settings?.role === "staff";
 
   // Fetch members list for admin/owner
-  const { data: membersData, isLoading: isMembersLoading } = useQuery({
-    queryKey: ["members"],
-    queryFn: async () => {
-      const response = await api.get<MembersResponse>("members");
-      return response;
-    },
-    enabled: isAdminOrOwner,
-  });
+  const { data: members, isLoading: isMembersLoading } = useGetStaffs(isAdminOrOwner);
 
   // Set default selected member to the first staff member for admin/owner
   useEffect(() => {
-    if (isAdminOrOwner && membersData?.success && !selectedMemberId) {
-      const staffMembers = membersData.data.members.filter(
+    if (isAdminOrOwner && !!members && !selectedMemberId) {
+      const staffMembers = members.filter(
         (member) => member.status === "accepted" && member.role === "staff"
       );
       if (staffMembers.length > 0) {
         setSelectedMemberId(staffMembers[0].id.toString());
       }
     }
-  }, [membersData, isAdminOrOwner, selectedMemberId]);
+  }, [members, isAdminOrOwner, selectedMemberId]);
 
   // Fetch bookings based on role and tab
   const { data: bookingsData, isLoading: isBookingsLoading } = useQuery({
@@ -124,8 +118,8 @@ export default function AppointmentsPage() {
                 <SelectItem value="loading" disabled>
                   Loading members...
                 </SelectItem>
-              ) : membersData?.success ? (
-                membersData.data.members
+              ) : members?.length ? (
+                members
                   .filter((member) => member.status === "accepted")
                   .map((member) => (
                     <SelectItem key={member.id} value={member.id.toString()}>

--- a/src/app/dashboard/calendar/page.tsx
+++ b/src/app/dashboard/calendar/page.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/select";
 import { useCompanyDetails } from "@/hooks/use-company-details";
 import { useFetchServices } from "@/hooks/use-fetch-services";
+import { useGetStaffs } from "@/hooks/use-get-staffs";
 
 export default function CalendarPage() {
   const { data: settings } = useCompanyDetails();
@@ -39,14 +40,7 @@ export default function CalendarPage() {
   const isStaff = settings?.role === "staff";
 
   // Fetch members list for admin/owner
-  const { data: membersData, isLoading: isMembersLoading } = useQuery({
-    queryKey: ["members"],
-    queryFn: async () => {
-      const response = await api.get<MembersResponse>("members");
-      return response;
-    },
-    enabled: isAdminOrOwner,
-  });
+  const { data: members, isLoading: isMembersLoading } = useGetStaffs(isAdminOrOwner);
 
   // Fetch bookings based on role
   const { data: bookingsData, isLoading: isBookingsLoading } = useQuery({
@@ -76,15 +70,15 @@ export default function CalendarPage() {
 
   // Set default selected member to the first staff member for admin/owner
   useEffect(() => {
-    if (isAdminOrOwner && membersData?.success && !selectedMemberId) {
-      const staffMembers = membersData.data.members.filter(
+    if (isAdminOrOwner && !!members && !selectedMemberId) {
+      const staffMembers = members.filter(
         (member) => member.status === "accepted" && member.role === "staff"
       );
       if (staffMembers.length > 0) {
         setSelectedMemberId(staffMembers[0].id.toString());
       }
     }
-  }, [membersData, isAdminOrOwner, selectedMemberId]);
+  }, [members, isAdminOrOwner, selectedMemberId]);
 
   const [filters, setFilters] = useState<FilterProps>({
     category: [],
@@ -245,8 +239,8 @@ export default function CalendarPage() {
                   <SelectItem value="loading" disabled>
                     Loading members...
                   </SelectItem>
-                ) : membersData?.success ? (
-                  membersData.data.members
+                ) : members?.length ? (
+                  members
                     .filter((member) => member.status === "accepted")
                     .map((member) => (
                       <SelectItem key={member.id} value={member.id.toString()}>

--- a/src/app/dashboard/calendar/page.tsx
+++ b/src/app/dashboard/calendar/page.tsx
@@ -99,7 +99,7 @@ export default function CalendarPage() {
     }
 
     return bookingsData.data.bookings.filter((booking) => {
-      const serviceId = booking.Service.id;
+      const serviceId = booking.service.id;
 
       // Check if the booking's service matches the selected service filters
       const matchesService =
@@ -175,13 +175,13 @@ export default function CalendarPage() {
     ? {
         bookings: bookingsData.data.bookings.map((booking) => ({
           id: booking.id,
-          Customer: booking.Booking.Customer,
-          service_ids: [booking.Service.id.toString()],
+          Customer: booking.booking.customer,
+          service_ids: [booking.service.id.toString()],
           event_date: booking.startTime,
           event_time: dayjs(booking.startTime).format("HH:mm"),
           event_duration: booking.duration,
           dns: false,
-          amount_paid: booking.Booking.amountPaid,
+          amount_paid: booking.booking.amountPaid,
         })),
         timeSlotDuration: settings?.timeslot_duration || 15,
         dayEnabled: true,

--- a/src/app/dashboard/calendar/page.tsx
+++ b/src/app/dashboard/calendar/page.tsx
@@ -250,7 +250,7 @@ export default function CalendarPage() {
                     .filter((member) => member.status === "accepted")
                     .map((member) => (
                       <SelectItem key={member.id} value={member.id.toString()}>
-                        {member.User.full_name} ({member.User.email})
+                        {member.user.full_name} ({member.user.email})
                       </SelectItem>
                     ))
                 ) : (

--- a/src/app/dashboard/services/page.tsx
+++ b/src/app/dashboard/services/page.tsx
@@ -21,6 +21,7 @@ import { useCompanyDetails } from "@/hooks/use-company-details";
 import { useFetchServices } from "@/hooks/use-fetch-services";
 import useFetchCategories from "@/hooks/use-fetch-categories";
 import { fetchMembers, mediumRefreshInterval } from "@/utils/api";
+import { useGetStaffs } from "@/hooks/use-get-staffs";
 
 export default function ServicesPage() {
   const { data: settings } = useCompanyDetails();
@@ -77,11 +78,7 @@ export default function ServicesPage() {
     }
   );
 
-  const { data: staffMembers } = useQuery({
-    queryKey: ["members"],
-    queryFn: fetchMembers,
-    staleTime: mediumRefreshInterval,
-  });
+  const { data: staffMembers } = useGetStaffs()
 
   const categories = categoriesData?.data.categories || [];
   const categoriesPagination = categoriesData?.data.pagination;

--- a/src/app/dashboard/stripe/page.tsx
+++ b/src/app/dashboard/stripe/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   Card,
   CardHeader,
@@ -13,11 +13,13 @@ import { Button } from "@/components/ui/button";
 import api from "@/services/api-service";
 import toast from "react-hot-toast";
 import SubscriptionDetails from "@/components/payments/subscription-card";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 // ------------------- Component -------------------
 export default function PaymentDashboardPage() {
   const router = useRouter();
+  const queryParams = useSearchParams()
+  const queryClient = useQueryClient()
   const { data, isLoading } = useQuery({
     queryKey: ["stripe-settings"],
     queryFn: async () => {
@@ -26,6 +28,14 @@ export default function PaymentDashboardPage() {
     },
     staleTime: 5 * 60 * 1000,
   });
+
+  useEffect(() => {
+    // Update stripe info after onboarding/portal visit
+    const accountIdPresent = !!queryParams.get('accountId')
+    if (accountIdPresent) {
+      queryClient.invalidateQueries({ queryKey: ["stripe-settings"] })
+    }
+  }, [])
 
   // Restrict access to admin and owner only
   useEffect(() => {

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -19,6 +19,7 @@ import { PendingInvitationsSection } from "@/components/team/pending-invitations
 import { InviteStaffDialog } from "@/components/team/invite-staff-dialog";
 import { StaffDetailsSheet } from "@/components/team/staff-details-sheet";
 import { fetchMembers, mediumRefreshInterval } from "@/utils/api";
+import { useGetStaffs } from "@/hooks/use-get-staffs";
 
 const roleOrder = { owner: 0, admin: 1, staff: 2 };
 const roleBadgeColors = {
@@ -35,11 +36,7 @@ export default function TeamPage() {
   const [selectedStaffId, setSelectedStaffId] = useState<number | null>(null);
 
   // Fetch members
-  const { data: membersData, isLoading: isLoadingMembers } = useQuery({
-    queryKey: ["members"],
-    queryFn: fetchMembers,
-    staleTime: mediumRefreshInterval,
-  });
+  const { data: membersData, isLoading: isLoadingMembers } = useGetStaffs();
 
   // Sort members by role and filter by search
   const sortedMembers = (Array.isArray(membersData) ? membersData : [])

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -48,8 +48,8 @@ export default function TeamPage() {
       if (!searchQuery) return true;
       const searchLower = searchQuery.toLowerCase();
       return (
-        member.User.full_name.toLowerCase().includes(searchLower) ||
-        member.User.email.toLowerCase().includes(searchLower) ||
+        member.user.full_name.toLowerCase().includes(searchLower) ||
+        member.user.email.toLowerCase().includes(searchLower) ||
         member.role.toLowerCase().includes(searchLower)
       );
     });
@@ -268,27 +268,27 @@ export default function TeamPage() {
                       />
 
                       <Avatar className="h-12 w-12">
-                        <AvatarImage src={member.User.avatar || undefined} />
+                        <AvatarImage src={member.user.avatar || undefined} />
                         <AvatarFallback className="bg-[#7B68EE] text-white">
-                          {getInitials(member.User.full_name)}
+                          {getInitials(member.user.full_name)}
                         </AvatarFallback>
                       </Avatar>
 
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
                           <h3 className="font-semibold text-[#121212] truncate">
-                            {member.User.full_name}
+                            {member.user.full_name}
                           </h3>
                           <Badge className={roleBadgeColors[member.role]}>
                             {member.role}
                           </Badge>
                         </div>
                         <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 text-sm text-[#6E6E73]">
-                          <span className="truncate">{member.User.email}</span>
-                          {member.User.phone && (
+                          <span className="truncate">{member.user.email}</span>
+                          {member.user.phone && (
                             <>
                               <span className="hidden sm:inline">•</span>
-                              <span>{member.User.phone}</span>
+                              <span>{member.user.phone}</span>
                             </>
                           )}
                         </div>

--- a/src/components/appointments/appointment-list.tsx
+++ b/src/components/appointments/appointment-list.tsx
@@ -49,21 +49,21 @@ export function AppointmentList({
               </div>
               <div className="flex-1">
                 <div className="font-medium text-[#121212]">
-                  {booking.Booking.Customer.name}
+                  {booking.booking.customer.name}
                 </div>
                 <div className="text-sm text-[#6E6E73]">
-                  {booking.Service.name} • £
+                  {booking.service.name} • £
                   {booking.price}
                 </div>
                 <div className="flex items-center gap-2 mt-1">
                   <div className="text-xs text-[#6E6E73] flex items-center gap-1">
                     <Mail className="w-3 h-3" />
-                    {booking.Booking.Customer.email}
+                    {booking.booking.customer.email}
                   </div>
-                  {booking.Booking.Customer.phone && (
+                  {booking.booking.customer.phone && (
                     <div className="text-xs text-[#6E6E73] flex items-center gap-1">
                       <Phone className="w-3 h-3" />
-                      {booking.Booking.Customer.phone}
+                      {booking.booking.customer.phone}
                     </div>
                   )}
                 </div>
@@ -71,10 +71,10 @@ export function AppointmentList({
                   <Badge
                     variant="outline"
                     className={getPaymentBadgeStyles(
-                      booking.Booking.payment_status
+                      booking.booking.payment_status
                     )}
                   >
-                    {booking.Booking.payment_status}
+                    {booking.booking.payment_status}
                   </Badge>
                 </div>
               </div>
@@ -87,8 +87,8 @@ export function AppointmentList({
                 {startTime.format("HH:mm")} • {booking.duration} min
               </div>
               <div className="text-xs text-[#6E6E73] mt-1">
-                £{booking.Booking.amount_paid} / £
-                {booking.Booking.amount_due + booking.Booking.amount_paid}
+                £{booking.booking.amount_paid} / £
+                {booking.booking.amount_due + booking.booking.amount_paid}
               </div>
             </div>
           </div>

--- a/src/components/calendar/calendar-card.tsx
+++ b/src/components/calendar/calendar-card.tsx
@@ -40,8 +40,6 @@ export default function CalendarCard({
   const startTimeIndex = getTimeSlotIndex(startTime, timeSlots);
   const duration = appointment.duration / 15;
 
-  const { data } = useFetchServices({ all: true });
-
   if (startTimeIndex === -1) return null;
   return (
     <div
@@ -58,13 +56,13 @@ export default function CalendarCard({
       <div className="relative flex flex-col">
         <div className="flex flex-col gap-2">
           <div className="font-medium text-[#121212]">
-            {appointment.Booking.Customer.name}
+            {appointment.booking.customer.name}
           </div>
           <div className="text-sm text-[#121212]">
             <p className="flex items-center gap-2">
               <Mail size={16} />{" "}
               <span className="inline-block text-ellipsis overflow-hidden">
-                {appointment.Booking.Customer.email}
+                {appointment.booking.customer.email}
               </span>
             </p>
           </div>
@@ -72,11 +70,11 @@ export default function CalendarCard({
             <p className="flex items-center gap-2">
               <Phone size={16} />{" "}
               <span className="inline-block">
-                {appointment.Booking.Customer.phone || "N/A"}
+                {appointment.booking.customer.phone || "N/A"}
               </span>
             </p>
           </div>
-          {appointment.Booking.dns && (
+          {appointment.booking.dns && (
             <Badge className="w-12 bg-red-400 text-white">DNS</Badge>
           )}
         </div>
@@ -95,7 +93,7 @@ export default function CalendarCard({
               <DropdownMenuLabel>Actions</DropdownMenuLabel>
               <DropdownMenuSeparator />
               <DropdownMenuItem
-                disabled={appointment.Booking.dns}
+                disabled={appointment.booking.dns}
                 onClick={() =>
                   setAppointment({ data: appointment, type: "cancel" })
                 }
@@ -104,7 +102,7 @@ export default function CalendarCard({
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
-                disabled={appointment.Booking.dns}
+                disabled={appointment.booking.dns}
                 onClick={() =>
                   setAppointment({ data: appointment, type: "reschedule" })
                 }
@@ -113,7 +111,7 @@ export default function CalendarCard({
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
-                disabled={appointment.Booking.dns}
+                disabled={appointment.booking.dns}
                 onClick={() =>
                   setAppointment({ data: appointment, type: "dns" })
                 }
@@ -128,7 +126,7 @@ export default function CalendarCard({
         <p className="flex items-center gap-2">
           <ClipboardList size={16} />{" "}
           <span className="inline-block">
-            {appointment.Service.name}
+            {appointment.service.name}
           </span>
         </p>
       </div>

--- a/src/components/services/service-form-dialog.tsx
+++ b/src/components/services/service-form-dialog.tsx
@@ -42,21 +42,12 @@ import {
   serviceDurationOptions,
 } from "@/lib/helpers";
 
-interface StaffMember {
-  id: number;
-  UserId: number;
-  ServiceProviderId: number;
-  role: "owner" | "admin" | "staff";
-  status: "pending" | "accepted" | "rejected";
-  User: MemberUser;
-}
-
 interface ServiceFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   service?: ServiceWithStaff | null;
   categories: { id: number; name: string }[];
-  staffMembers: StaffMember[];
+  staffMembers: Member[];
   onSubmit: (values: ServiceFormValues, serviceId?: number) => void;
   isSubmitting: boolean;
   disabled?: boolean;
@@ -325,15 +316,15 @@ export function ServiceFormDialog({
                           >
                             <Avatar className="h-5 w-5">
                               <AvatarImage
-                                src={staff.User.avatar || undefined}
-                                alt={staff.User.full_name}
+                                src={staff.user.avatar || undefined}
+                                alt={staff.user.full_name}
                               />
                               <AvatarFallback className="text-xs">
-                                {getInitials(staff.User.full_name)}
+                                {getInitials(staff.user.full_name)}
                               </AvatarFallback>
                             </Avatar>
                             <span className="text-sm">
-                              {staff.User.full_name}
+                              {staff.user.full_name}
                             </span>
                             <button
                               type="button"
@@ -378,15 +369,15 @@ export function ServiceFormDialog({
                             <div className="flex items-center gap-2">
                               <Avatar className="h-6 w-6">
                                 <AvatarFallback className="text-xs">
-                                  {getInitials(member.User.full_name)}
+                                  {getInitials(member.user.full_name)}
                                 </AvatarFallback>
                               </Avatar>
                               <div className="flex flex-col">
                                 <span className="text-sm">
-                                  {member.User.full_name}
+                                  {member.user.full_name}
                                 </span>
                                 <span className="text-xs text-muted-foreground">
-                                  {member.User.email}
+                                  {member.user.email}
                                 </span>
                               </div>
                             </div>

--- a/src/hooks/use-get-staffs.ts
+++ b/src/hooks/use-get-staffs.ts
@@ -1,0 +1,11 @@
+import { fetchMembers, mediumRefreshInterval } from "@/utils/api";
+import { useQuery } from "@tanstack/react-query";
+
+export function useGetStaffs(enabled: boolean = true) {
+  return useQuery({
+    queryKey: ["members"],
+    queryFn: fetchMembers,
+    staleTime: mediumRefreshInterval,
+    enabled,
+  });
+}

--- a/src/types/response.d.ts
+++ b/src/types/response.d.ts
@@ -938,21 +938,21 @@ interface StaffBookingItem {
   notes: string | null;
   createdAt: string;
   updatedAt: string;
-  Booking: {
+  booking: {
     id: number;
     uuid: string;
     status: string;
     paymentStatus: string;
     amountPaid: number;
     amountDue: number;
-    Customer: {
+    customer: {
       id: number;
       name: string;
       email: string;
       phone: string;
     };
   };
-  Service: {
+  service: {
     id: number;
     title: string;
     description: string | null;
@@ -1038,7 +1038,7 @@ interface BookingListItem {
   duration: number;
   status: string;
   price: number;
-  Booking: {
+  booking: {
     id: number;
     uuid: string;
     status: string;
@@ -1046,14 +1046,14 @@ interface BookingListItem {
     amount_paid: number;
     amount_due: number;
     dns: boolean;
-    Customer: {
+    customer: {
       id: number;
       name: string;
       email: string;
       phone: string;
     };
   };
-  Service: {
+  service: {
     id: number;
     name: string;
     description: string | null;

--- a/src/types/response.d.ts
+++ b/src/types/response.d.ts
@@ -1014,7 +1014,7 @@ interface Member {
   acceptedAt: string | null;
   createdAt: string;
   updatedAt: string;
-  User: MemberUser;
+  user: MemberUser;
   Inviter: {
     id: number;
     full_name: string;


### PR DESCRIPTION
# Frontend PR — `fix/cancel-reservation-session-id` → `main`

**Repo:** `ubonisrael/bnb-v2`
**Open at:** https://github.com/ubonisrael/bnb-v2/pull/new/fix/cancel-reservation-session-id
**Size:** 4 commits, 13 files

---

## Summary

Switches checkout-abandon cancellation to the new `sessionId` contract, and realigns dashboard
response types with the backend. Pairs with the backend PR
(`Banknbook/banknbook-api` → `fix/double-booking-cancel-flow`) — **the two must ship together**,
since the `/cancel-reservation` request body changes.

## What changed

### Cancel-reservation now sends `sessionId` (`b0a9cf2`)

`src/app/booking/[businessUrl]/landing.tsx` — on returning from Stripe with `status=canceled`, the
booking page now reads `sessionId` from the query string and posts `{ sessionId }` instead of
`{ productId, productType }`.

The backend uses that to expire the Stripe checkout session, which releases the slot via the
`checkout.session.expired` webhook rather than releasing it directly. Releasing directly was
causing double-bookings: pressing "cancel" on Stripe fires no event and leaves the session still
payable, so a customer could complete payment on a slot that had already been freed. Keying on the
unguessable session id also closes an IDOR on that endpoint.

### Shared staff-fetching hook (`4bac517`)

Staff data was being fetched in several places with **different return shapes**, which was throwing
at runtime depending on which component read it. Adds `src/hooks/use-get-staffs.ts` — a
`useQuery`-based hook with one standard return type — and updates the appointments, calendar,
services, and team dashboard pages to use it. Net −7 lines.

### Response types realigned with the backend (`cc896f0`, `72d79bc`)

- Booking response types in the calendar page, appointment list, and calendar card now match what
  the backend actually returns (`src/types/response.d.ts`).
- User data response type corrected.
- Stripe dashboard page refetches Stripe info after a portal visit, so the UI reflects account
  changes on return instead of showing stale state.

## Risk

- **Breaking, coupled to the backend.** Deploying this alone means `/cancel-reservation` receives
  `sessionId` against a backend still expecting `productId`/`productType`. Deploying the backend
  alone means the reverse. Ship together.
- The type changes are compile-time only; the runtime behavior change is confined to the
  cancellation path and the Stripe page refetch.

## Testing

Type-level changes are covered by the build. The cancellation path is worth a manual pass: start a
booking, reach Stripe Checkout, press cancel, and confirm the slot is released (via the backend's
`checkout.session.expired` handler) and becomes bookable again.
